### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `eg` or `cp`)"
+  default     = ""
 }
 
 variable "stage" {


### PR DESCRIPTION
# Description

Makes `namespace` var optional, since the label module supports that.
(fixes name length on s3 creation error) 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update